### PR TITLE
0.10.0 build 1 and examples package

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,13 +5,14 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_64_
   timeoutInMinutes: 360
 
   steps:
@@ -39,8 +40,7 @@ jobs:
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
   - script: |
-        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d build_artifacts ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,11 +52,11 @@ if [ -z "${DOCKER_IMAGE}" ]; then
         echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
         DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
         if [ "${DOCKER_IMAGE}" = "" ]; then
-            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
-            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+            echo "No docker_image entry found in ${CONFIG}. Falling back to quay.io/condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="quay.io/condaforge/linux-anvil-comp7"
         fi
     else
-        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 quay.io/condaforge/linux-anvil-comp7 )"
     fi
 fi
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-openff--toolkit-green.svg)](https://anaconda.org/conda-forge/openff-toolkit) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openff-toolkit.svg)](https://anaconda.org/conda-forge/openff-toolkit) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openff-toolkit.svg)](https://anaconda.org/conda-forge/openff-toolkit) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openff-toolkit.svg)](https://anaconda.org/conda-forge/openff-toolkit) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-openff--toolkit--base-green.svg)](https://anaconda.org/conda-forge/openff-toolkit-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openff-toolkit-base.svg)](https://anaconda.org/conda-forge/openff-toolkit-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openff-toolkit-base.svg)](https://anaconda.org/conda-forge/openff-toolkit-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openff-toolkit-base.svg)](https://anaconda.org/conda-forge/openff-toolkit-base) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-openff--toolkit--examples-green.svg)](https://anaconda.org/conda-forge/openff-toolkit-examples) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openff-toolkit-examples.svg)](https://anaconda.org/conda-forge/openff-toolkit-examples) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openff-toolkit-examples.svg)](https://anaconda.org/conda-forge/openff-toolkit-examples) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openff-toolkit-examples.svg)](https://anaconda.org/conda-forge/openff-toolkit-examples) |
 
 Installing openff-toolkit-split
 ===============================
@@ -49,10 +50,10 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `openff-toolkit, openff-toolkit-base` can be installed with:
+Once the `conda-forge` channel has been enabled, `openff-toolkit, openff-toolkit-base, openff-toolkit-examples` can be installed with:
 
 ```
-conda install openff-toolkit openff-toolkit-base
+conda install openff-toolkit openff-toolkit-base openff-toolkit-examples
 ```
 
 It is possible to list all of the versions of `openff-toolkit` available on your platform with:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,6 +78,9 @@ outputs:
         - openmmforcefields
         - {{ pin_subpackage('openff-toolkit', exact=True) }}
 
+    test:
+      script: test_examples_copied.py
+
 about:
   home: https://openforcefield.org/
   license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/refs/heads/examples_helper.zip
-    sha256: 9e7b43a3e79760b3293c5ddb6556feb4196025e1f3325c3866cdc997c2d6b073
+    sha256: 3f7f14b58d493a98a523654dd13e6edc1013685dc65221c0ff5242c634ab312b
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
-    sha256: 5bea41fdf5af5ffec8ca5203b714d0c7359507762df919cd42d1fec3b2de1686
+    sha256: b15aec2b0d4ae6384d96a6b53178a22be95ac39760b3a534ba740463eb819a27
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ outputs:
 
   - name: openff-toolkit-examples
     files:
-      - examples/*/*
+      - openff-toolkit-{{ version }}/examples
     build:
       noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/refs/heads/examples_helper.zip
-    sha256: 3f7f14b58d493a98a523654dd13e6edc1013685dc65221c0ff5242c634ab312b
+    sha256: 36d8bcbea8cf77c25b8dd232754b579c79927e19da8245ed363a325ee74f9aab
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,7 +79,11 @@ outputs:
         - {{ pin_subpackage('openff-toolkit', exact=True) }}
 
     test:
-      script: test_examples_copied.py
+      files:
+        - test_examples_copied.py
+        - examples
+      commands:
+        - python test_examples_copied.py
 
 about:
   home: https://openforcefield.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,53 +14,53 @@ build:
   number: 1
 
 outputs:
-  - name: openff-toolkit-base
-    script: build_base.sh
-    build:
-      noarch: python
+  # - name: openff-toolkit-base
+  #   script: build_base.sh
+  #   build:
+  #     noarch: python
 
-    requirements:
-      host:
-        - python >=3.6
-        - pip
-      run:
-        - python >=3.6
-        - packaging
-        - numpy
-        - smirnoff99frosst
-        - openff-forcefields
-        - openmm
-        - networkx
-        - mdtraj
-        - xmltodict
-      run_constrained:
-        - openforcefield ==9999999999
+  #   requirements:
+  #     host:
+  #       - python >=3.6
+  #       - pip
+  #     run:
+  #       - python >=3.6
+  #       - packaging
+  #       - numpy
+  #       - smirnoff99frosst
+  #       - openff-forcefields
+  #       - openmm
+  #       - networkx
+  #       - mdtraj
+  #       - xmltodict
+  #     run_constrained:
+  #       - openforcefield ==9999999999
 
-    test:
-      imports:
-        - openff.toolkit
+  #   test:
+  #     imports:
+  #       - openff.toolkit
 
-  - name: openff-toolkit
-    build:
-      noarch: python
+  # - name: openff-toolkit
+  #   build:
+  #     noarch: python
 
-    requirements:
-      host:
-        - python >=3.6
-      run:
-        - python >=3.6
-        - rdkit
-        - ambertools >=20
-        - {{ pin_subpackage('openff-toolkit-base', exact=True) }}
+  #   requirements:
+  #     host:
+  #       - python >=3.6
+  #     run:
+  #       - python >=3.6
+  #       - rdkit
+  #       - ambertools >=20
+  #       - {{ pin_subpackage('openff-toolkit-base', exact=True) }}
 
-    test:
-      imports:
-        - openff.toolkit
-        - rdkit
-      files:
-        - test_openff_toolkit_base.py
-      commands:
-        - python test_openff_toolkit_base.py
+  #   test:
+  #     imports:
+  #       - openff.toolkit
+  #       - rdkit
+  #     files:
+  #       - test_openff_toolkit_base.py
+  #     commands:
+  #       - python test_openff_toolkit_base.py
 
   - name: openff-toolkit-examples
     script: move-examples.sh
@@ -69,6 +69,7 @@ outputs:
 
     requirements:
       run:
+        - python >=3.6
         - nglview
         - notebook
         - qcelemental
@@ -80,7 +81,7 @@ outputs:
     test:
       files:
         - test_examples_copied.py
-      source-files:
+      source_files:
         - examples
       commands:
         - python test_examples_copied.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,53 +14,53 @@ build:
   number: 1
 
 outputs:
-  # - name: openff-toolkit-base
-  #   script: build_base.sh
-  #   build:
-  #     noarch: python
+  - name: openff-toolkit-base
+    script: build_base.sh
+    build:
+      noarch: python
 
-  #   requirements:
-  #     host:
-  #       - python >=3.6
-  #       - pip
-  #     run:
-  #       - python >=3.6
-  #       - packaging
-  #       - numpy
-  #       - smirnoff99frosst
-  #       - openff-forcefields
-  #       - openmm
-  #       - networkx
-  #       - mdtraj
-  #       - xmltodict
-  #     run_constrained:
-  #       - openforcefield ==9999999999
+    requirements:
+      host:
+        - python >=3.6
+        - pip
+      run:
+        - python >=3.6
+        - packaging
+        - numpy
+        - smirnoff99frosst
+        - openff-forcefields
+        - openmm
+        - networkx
+        - mdtraj
+        - xmltodict
+      run_constrained:
+        - openforcefield ==9999999999
 
-  #   test:
-  #     imports:
-  #       - openff.toolkit
+    test:
+      imports:
+        - openff.toolkit
 
-  # - name: openff-toolkit
-  #   build:
-  #     noarch: python
+  - name: openff-toolkit
+    build:
+      noarch: python
 
-  #   requirements:
-  #     host:
-  #       - python >=3.6
-  #     run:
-  #       - python >=3.6
-  #       - rdkit
-  #       - ambertools >=20
-  #       - {{ pin_subpackage('openff-toolkit-base', exact=True) }}
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - python >=3.6
+        - rdkit
+        - ambertools >=20
+        - {{ pin_subpackage('openff-toolkit-base', exact=True) }}
 
-  #   test:
-  #     imports:
-  #       - openff.toolkit
-  #       - rdkit
-  #     files:
-  #       - test_openff_toolkit_base.py
-  #     commands:
-  #       - python test_openff_toolkit_base.py
+    test:
+      imports:
+        - openff.toolkit
+        - rdkit
+      files:
+        - test_openff_toolkit_base.py
+      commands:
+        - python test_openff_toolkit_base.py
 
   - name: openff-toolkit-examples
     script: move-examples.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,8 @@ package:
 
 source:
   - path: ./build_base.sh
-  - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
-    sha256: b15aec2b0d4ae6384d96a6b53178a22be95ac39760b3a534ba740463eb819a27
+  - url: https://github.com/openforcefield/openff-toolkit/archive/refs/heads/examples_helper.zip
+    sha256: 9e7b43a3e79760b3293c5ddb6556feb4196025e1f3325c3866cdc997c2d6b073
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
-    sha256: b15aec2b0d4ae6384d96a6b53178a22be95ac39760b3a534ba740463eb819a27
+    sha256: ca50e824b917e562aa01da2f77489f81538b82125d5b322665601ed37e9b06bd
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,6 @@ outputs:
       run:
         - nglview
         - notebook
-        - gromacs
         - qcelemental
         - qcportal
         - qcengine
@@ -81,6 +80,7 @@ outputs:
     test:
       files:
         - test_examples_copied.py
+      source-files:
         - examples
       commands:
         - python test_examples_copied.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openff-toolkit" %}
-{% set version = "0.9.2" %}
+{% set version = "0.10.0" %}
 
 package:
   name: openff-toolkit-split
@@ -11,7 +11,7 @@ source:
     sha256: b15aec2b0d4ae6384d96a6b53178a22be95ac39760b3a534ba740463eb819a27
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: openff-toolkit-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,8 @@ package:
 
 source:
   - path: ./build_base.sh
-  - url: https://github.com/openforcefield/openff-toolkit/archive/refs/heads/examples_helper.zip
-    sha256: 36d8bcbea8cf77c25b8dd232754b579c79927e19da8245ed363a325ee74f9aab
-
+  - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
+    sha256: b15aec2b0d4ae6384d96a6b53178a22be95ac39760b3a534ba740463eb819a27
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,9 @@ outputs:
 
   - name: openff-toolkit-examples
     files:
-      - examples
+      - examples/*/*
+    build:
+      noarch: python
 
     requirements:
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 5bea41fdf5af5ffec8ca5203b714d0c7359507762df919cd42d1fec3b2de1686
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-toolkit-base
@@ -61,6 +61,21 @@ outputs:
         - test_openff_toolkit_base.py
       commands:
         - python test_openff_toolkit_base.py
+
+  - name: openff-toolkit-examples
+    files:
+      - examples
+
+    requirements:
+      run:
+        - nglview
+        - notebook
+        - gromacs
+        - qcelemental
+        - qcportal
+        - qcengine
+        - openmmforcefields
+        - {{ pin_subpackage('openff-toolkit', exact=True) }}
 
 about:
   home: https://openforcefield.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,8 +63,7 @@ outputs:
         - python test_openff_toolkit_base.py
 
   - name: openff-toolkit-examples
-    files:
-      - openff-toolkit-{{ version }}/examples
+    script: move-examples.sh
     build:
       noarch: python
 

--- a/recipe/move-examples.sh
+++ b/recipe/move-examples.sh
@@ -1,5 +1,11 @@
-mkdir -p $CONDA_PREFIX/share/openff-toolkit
-cp -r examples $CONDA_PREFIX/share/openff-toolkit
+#! /bin/bash
 
-mv $CONDA_PREFIX/share/openff-toolkit/examples/examples_helper.py $CONDA_PREFIX/bin/openff-toolkit-examples
-chmod +x $CONDA_PREFIX/bin/openff-toolkit-examples
+# Shell safety: Exit script on error, treat unset variables as error, propagate errors out of pipelines
+set -eu -o pipefail
+
+mkdir -p "$CONDA_PREFIX/share/openff-toolkit"
+cp -r examples "$CONDA_PREFIX/share/openff-toolkit"
+
+mkdir -p "$CONDA_PREFIX/bin"
+mv "$CONDA_PREFIX/share/openff-toolkit/examples/examples_helper.py" "$CONDA_PREFIX/bin/openff-toolkit-examples"
+chmod +x "$CONDA_PREFIX/bin/openff-toolkit-examples"

--- a/recipe/move-examples.sh
+++ b/recipe/move-examples.sh
@@ -1,2 +1,5 @@
 mkdir -p $CONDA_PREFIX/share/openff-toolkit
 cp -r examples $CONDA_PREFIX/share/openff-toolkit
+
+mv $CONDA_PREFIX/share/openff-toolkit/examples/examples_helper.py $CONDA_PREFIX/bin/openff-toolkit-examples
+chmod +x $CONDA_PREFIX/bin/openff-toolkit-examples

--- a/recipe/move-examples.sh
+++ b/recipe/move-examples.sh
@@ -1,0 +1,2 @@
+mkdir -p $CONDA_PREFIX/share/openff-toolkit
+cp -r examples $CONDA_PREFIX/share/openff-toolkit

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -24,7 +24,7 @@ def main():
     print("Installed examples tree:", *installed_tree, sep="\n    ")
 
     # Remove the helper script, which is moved to the bin directory during installation
-    repo_tree.remove("examples_helper.py")
+    repo_tree.remove(Path("examples_helper.py"))
 
     # Check that the (filtered) file trees match, and are not empty
     assert repo_tree, "Source repository tree is empty"

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from os import environ
+from subprocess import run
 
 
 def file_tree(path):
@@ -12,19 +13,32 @@ def file_tree(path):
 
 def main():
     """Entrypoint for this test"""
-    repo_path = Path("examples")
-    installed_path = Path(environ["CONDA_PREFIX"]) / "share/openff-toolkit/examples"
+    # Get lists of the examples files in source and installation
+    repo_tree = file_tree("examples")
+    installed_tree = file_tree(
+        Path(environ["CONDA_PREFIX"]) / "share/openff-toolkit/examples"
+    )
 
-    repo_tree = file_tree(repo_path)
-    installed_tree = file_tree(installed_path)
-
+    # Print the trees out for debugging
     print("Source repository examples tree:", *repo_tree, sep="\n    ")
     print("Installed examples tree:", *installed_tree, sep="\n    ")
 
+    # Remove the helper script, which is moved to the bin directory during installation
+    repo_tree.remove("examples_helper.py")
+
+    # Check that the (filtered) file trees match, and are not empty
     assert repo_tree, "Source repository tree is empty"
-    assert (
-        repo_tree == installed_tree
-    ), "Source repository tree doesn't match installed tree"
+    assert repo_tree == installed_tree, "Source repo tree doesn't match installed tree"
+
+    # Run the examples helper and check what files it copies over
+    helper_test_path = Path("helper_test_target")
+    helper_test_path.mkdir()
+    run("openff-toolkit-examples", cwd=helper_test_path, check=True)
+    helper_test_tree = file_tree(helper_test_path / "examples")
+
+    # Print and check the helper test
+    print("Examples helper target tree:", *helper_test_tree, sep="\n    ")
+    assert helper_test_tree == repo_tree, "Examples helper failed to install all files"
 
 
 if __name__ == "__main__":

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -1,0 +1,30 @@
+"""Test that examples copied to CONDA_PREFIX by move-examples.sh are correct"""
+
+from pathlib import Path
+from os import environ
+
+
+def file_trees_match(left, right):
+    """True if the file paths at left and right have identical contents, false otherwise"""
+    a = Path(left).glob("**")
+    b = Path(right).glob("**")
+
+    return sorted(a) == sorted(b)
+
+
+def is_empty(path):
+    """True if the given path contains no real files"""
+    return len([p for p in Path(path).glob("*") if p.is_file()]) == 0
+
+
+def main():
+    """Entrypoint for this test"""
+    repo_examples = Path("examples")
+    installed_examples = Path(environ["CONDA_PREFIX"]) / "share/openff-toolkit/examples"
+
+    assert file_trees_match(repo_examples, installed_examples)
+    assert not is_empty(installed_examples)
+
+
+if __name__ == "__main__":
+    main()

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -18,8 +18,8 @@ def main():
     repo_tree = file_tree(repo_path)
     installed_tree = file_tree(installed_path)
 
-    print("Source repository examples tree:", repo_tree, sep="\n")
-    print("Installed examples tree:", installed_tree, sep="\n")
+    print("Source repository examples tree:", *repo_tree, sep="\n    ")
+    print("Installed examples tree:", *installed_tree, sep="\n    ")
     print("This message was sent to stderr, can you see it in Azure?", file=stderr)
 
     assert repo_tree

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -14,7 +14,7 @@ def file_trees_match(left, right):
 
 def is_empty(path):
     """True if the given path contains no real files"""
-    return len([p for p in Path(path).glob("*") if p.is_file()]) == 0
+    return len([p for p in Path(path).glob("**") if p.is_file()]) == 0
 
 
 def main():

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -2,28 +2,28 @@
 
 from pathlib import Path
 from os import environ
+from sys import stderr
 
 
-def file_trees_match(left, right):
-    """True if the file paths at left and right have identical contents, false otherwise"""
-    a = Path(left).glob("**")
-    b = Path(right).glob("**")
-
-    return sorted(a) == sorted(b)
-
-
-def is_empty(path):
-    """True if the given path contains no real files"""
-    return len([p for p in Path(path).glob("**") if p.is_file()]) == 0
+def file_tree(path):
+    """Get the entire tree of real files at path, sorted into a list"""
+    return sorted([p for p in Path(path).glob("**") if p.is_file()])
 
 
 def main():
     """Entrypoint for this test"""
-    repo_examples = Path("examples")
-    installed_examples = Path(environ["CONDA_PREFIX"]) / "share/openff-toolkit/examples"
+    repo_path = Path("examples")
+    installed_path = Path(environ["CONDA_PREFIX"]) / "share/openff-toolkit/examples"
 
-    assert file_trees_match(repo_examples, installed_examples)
-    assert not is_empty(installed_examples)
+    repo_tree = file_tree(repo_path)
+    installed_tree = file_tree(installed_path)
+
+    print("Source repository examples tree:", repo_tree, sep="\n")
+    print("Installed examples tree:", installed_tree, sep="\n")
+    print("This message was sent to stderr, can you see it in Azure?", file=stderr)
+
+    assert repo_tree
+    assert repo_tree == installed_tree
 
 
 if __name__ == "__main__":

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -18,6 +18,8 @@ def main():
     repo_tree = file_tree(repo_path)
     installed_tree = file_tree(installed_path)
 
+    print("Working directory tree:", *file_tree("."), sep="\n    ")
+
     print("Source repository examples tree:", *repo_tree, sep="\n    ")
     print("Installed examples tree:", *installed_tree, sep="\n    ")
     print("This message was sent to stderr, can you see it in Azure?", file=stderr)

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -2,12 +2,12 @@
 
 from pathlib import Path
 from os import environ
-from sys import stderr
 
 
 def file_tree(path):
-    """Get the entire tree of real files at path, sorted into a list"""
-    return sorted([p for p in Path(path).glob("**") if p.is_file()])
+    """Get the entire tree of files at path, sorted into a list"""
+    root = Path(path)
+    return sorted([p.relative_to(root) for p in root.glob("**/*")])
 
 
 def main():
@@ -18,14 +18,13 @@ def main():
     repo_tree = file_tree(repo_path)
     installed_tree = file_tree(installed_path)
 
-    print("Working directory tree:", *file_tree("."), sep="\n    ")
-
     print("Source repository examples tree:", *repo_tree, sep="\n    ")
     print("Installed examples tree:", *installed_tree, sep="\n    ")
-    print("This message was sent to stderr, can you see it in Azure?", file=stderr)
 
-    assert repo_tree
-    assert repo_tree == installed_tree
+    assert repo_tree, "Source repository tree is empty"
+    assert (
+        repo_tree == installed_tree
+    ), "Source repository tree doesn't match installed tree"
 
 
 if __name__ == "__main__":

--- a/recipe/test_examples_copied.py
+++ b/recipe/test_examples_copied.py
@@ -33,7 +33,11 @@ def main():
     # Run the examples helper and check what files it copies over
     helper_test_path = Path("helper_test_target")
     helper_test_path.mkdir()
-    run("openff-toolkit-examples", cwd=helper_test_path, check=True)
+    run(
+        ["openff-toolkit-examples", "--include-deprecated"],
+        cwd=helper_test_path,
+        check=True,
+    )
     helper_test_tree = file_tree(helper_test_path / "examples")
 
     # Print and check the helper test


### PR DESCRIPTION
The  `openff-toolkit` repository has a number of example notebooks that demonstrate its use, and we're about to put a bunch of effort into improving them and adding more. In openforcefield/openff-toolkit#888, I investigated adding tooling to simplify the use of the examples, and we discovered that they were not distributed with the toolkit by Conda. This PR adds a new subpackage, `openff-toolkit-examples`, that includes the examples themselves as well as depending on the packages required to run them. In the future, this package may also include a helper application to run the examples, but using this packaging method allows us to let Conda manage package management.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
