### PR TITLE
pin networkx to >=2.5, update build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
-    sha256: 5bea41fdf5af5ffec8ca5203b714d0c7359507762df919cd42d1fec3b2de1686
+    sha256: b15aec2b0d4ae6384d96a6b53178a22be95ac39760b3a534ba740463eb819a27
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 5bea41fdf5af5ffec8ca5203b714d0c7359507762df919cd42d1fec3b2de1686
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-toolkit-base
@@ -30,7 +30,7 @@ outputs:
         - smirnoff99frosst
         - openff-forcefields
         - openmm
-        - networkx
+        - networkx >=2.5
         - mdtraj
         - xmltodict
       run_constrained:


### PR DESCRIPTION
Fixes https://github.com/openforcefield/openff-toolkit/issues/918

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
