### PR TITLE
Pin OpenMM to 7.5.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ outputs:
         - numpy
         - smirnoff99frosst
         - openff-forcefields
-        - openmm
+        - openmm =7.5.*
         - networkx >=2.5
         - mdtraj
         - xmltodict


### PR DESCRIPTION
OpenMM 7.6 will break anything that relies on `parmed.openmm.load_topology` until https://github.com/ParmEd/ParmEd/issues/1185 is resolved. Users updating everything to newer versions and/or creating new environments will likely have 7.6, so we should consider pinning to 7.5.x to avoid this while it is still an issue.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
