### PR TITLE
Update hash of 0.11.2 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,10 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
-    sha256: 11e2c7010b0d2e151ae8d8eb894e33fbf22b357cdce20df460a7146ea3c149ec
+    sha256: 0f8a8fcb8a4c8c31b7a5b23a48210de32c16d4d733f477ba759b549fb49a04a5
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-toolkit-base


### PR DESCRIPTION
With my luck, GitHub updates the release assets between me getting reliably passing status checks on #31 and actually merging it: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=591964&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d

 <!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
