### PR TITLE
Move MDTraj to full recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ outputs:
         - openff-units >=0.1.7
         - openff-utilities
         - networkx >=2.5
-        - mdtraj
         - xmltodict
         - importlib-metadata >=4.10
         - python-constraint
@@ -57,10 +56,11 @@ outputs:
       run:
         - python >=3.8
         - openmm >=7.6
+        - {{ pin_subpackage('openff-toolkit-base', exact=True) }}
         - openff-interchange >=0.2.0
         - rdkit
         - ambertools >=20
-        - {{ pin_subpackage('openff-toolkit-base', exact=True) }}
+        - mdtraj
         - notebook
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 0f8a8fcb8a4c8c31b7a5b23a48210de32c16d4d733f477ba759b549fb49a04a5
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: openff-toolkit-base


### PR DESCRIPTION
The toolkit does not depend on MDTraj (#29) so we could at least not require it be pulled in with the base build.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
