### PR TITLE
Update SHA hash again

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
-    sha256: 394355d9a00f3aa8da272cd8cdb24fa62d59069e7a76b5cc3c2961b856157553
+    sha256: f70244d61c4b2547c3ff8a88a49a84617b1281d684e7c0561b75f68325326d6c
 
 build:
   number: 0


### PR DESCRIPTION
The GitHub archive changed between the last commit of #39 and its merging, which caused the build to fail.

https://github.com/conda-forge/openff-toolkit-feedstock/commit/7b3677d4194f9b43f789335827885881d1a4bf6a

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=636784&view=logs&jobId=656edd35-690f-5c53-9ba3-09c10d0bea97&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d


```console
$ curl -sL https://github.com/openforcefield/openff-toolkit/archive/0.12.0.tar.gz | openssl sha256
(stdin)= f70244d61c4b2547c3ff8a88a49a84617b1281d684e7c0561b75f68325326d6c
```
I'm not updating the build number because build 0 does not exist.

 <!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
