### PR TITLE
Fix 0.13.0 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ outputs:
         - openmm >=7.6
         - openff-interchange >=0.3.0
         - rdkit
-        - ambertools >=20
+        - ambertools >=22
         - mdtraj
         - {{ pin_subpackage('openff-toolkit-base', exact=True) }}
         - notebook

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
-    sha256: c25c13fc23a667f45dc95f9453b1a349ff97c0133271bb884023dc8158924164
+    sha256: 24953d489b1f5ce9f1169cd6e5d3efef1d47bc92524a1c7d9162a8982c5aa963
 
 build:
   number: 0


### PR DESCRIPTION
There was no package built from #46 so I don't think there's a need to bump the version number


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
