### PR TITLE
Constrain around incompatible `typing_extensions`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ outputs:
         - python-constraint
         - cachetools
         - cached-property
-        - typing_extensions
+        - typing_extensions !=4.6.0
       run_constrained:
         - openforcefield ==9999999999
         - importlib_metadata >=4.10 # https://github.com/conda-forge/openff-toolkit-feedstock/pull/37#issuecomment-1314260590

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 24953d489b1f5ce9f1169cd6e5d3efef1d47bc92524a1c7d9162a8982c5aa963
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-toolkit-base


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
