### PR TITLE
Constrain `pydantic =1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,8 @@ outputs:
         - typing_extensions
       run_constrained:
         - openforcefield ==9999999999
-        - importlib_metadata >=4.10 # https://github.com/conda-forge/openff-toolkit-feedstock/pull/37#issuecomment-1314260590
+        - pydantic =1
+
     test:
       imports:
         - openff.toolkit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ outputs:
         - openff-utilities
         - networkx >=2.5
         - xmltodict
+        - bson
         - importlib-metadata >=4.10
         - python-constraint
         - cachetools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: a1a4647ecaae364a8c8321c4c792d68f0336588c435156d24ac5153eb88b9032
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: openff-toolkit-base


### PR DESCRIPTION
I'm soon rolling out support for Pydantic 2 in some upstreams, and I'm constraining it wherever I haven't tested it yet.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
