### PR TITLE
Pin examples to Pydantic v1 because of QCPortal

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 736fd5aa6e5f08faf55dd51708849184bf8cd4230d35a3ac189d6843f8faba69
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-toolkit-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,6 +91,9 @@ outputs:
         - openmmforcefields  # Expected to bring in 0.11.2, add constraint if this is an issue
         - pdbfixer
         - {{ pin_subpackage('openff-toolkit', exact=True) }}
+      run_constrained:
+        # QCPortal has not been updated to work with Pydantic 2
+        - pydantic =1
 
     test:
       files:


### PR DESCRIPTION
QCPortal has not been updated to work with Pydantic v2 and will not be for the foreseeable future. We don't need it at runtime, but the examples use it.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
