### PR TITLE
Constrain `zstandard ==0.18` for OEChem compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ outputs:
         - openforcefield ==9999999999
         - pydantic <3.0.0a0
         - qcportal >=0.50.0
+        # Remove when OpenEye has builds that use zstandard >=0.19
         - zstandard ==0.18
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   - path: ./build_base.sh
   - url: https://github.com/openforcefield/openff-toolkit/archive/{{ version }}.tar.gz
-    sha256: e46cec736ce6d5c97bb17c996869737b91f322f4736ead1493bcb94acc066948
+    sha256: 1c1aa2ac9fff7c1613168531884da4ade53cbe21069022c999996d7effd2474c
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,8 @@ outputs:
         - ipywidgets
 
     test:
+      requires:
+        - qcportal
       imports:
         - openff.toolkit
         - rdkit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: e46cec736ce6d5c97bb17c996869737b91f322f4736ead1493bcb94acc066948
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: openff-toolkit-base
@@ -44,6 +44,7 @@ outputs:
         - openforcefield ==9999999999
         - pydantic <3.0.0a0
         - qcportal >=0.50.0
+        - zstandard ==0.18
 
     test:
       imports:

--- a/recipe/test_openff_toolkit.py
+++ b/recipe/test_openff_toolkit.py
@@ -4,15 +4,25 @@ from openff.toolkit.utils.toolkits import (
     RDKitToolkitWrapper,
 )
 
-assert RDKitToolkitWrapper().is_available()
-assert AmberToolsToolkitWrapper().is_available()
-
-
-print(GLOBAL_TOOLKIT_REGISTRY.registered_toolkit_versions)
+import qcportal
 
 from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.typing.engines.smirnoff import ForceField
+
+print(GLOBAL_TOOLKIT_REGISTRY.registered_toolkit_versions)
+
+assert RDKitToolkitWrapper().is_available()
+assert AmberToolsToolkitWrapper().is_available()
+
 offmol = Molecule.from_smiles('CCO')
 Molecule.from_rdkit(offmol.to_rdkit())
 ff = ForceField('openff-1.0.0.offxml')
 ff.create_openmm_system(offmol.to_topology())
+
+client = PortalClient("https://api.qcarchive.molssi.org:443/")
+
+# copied from cookbook, there's probably a lighter way to do this
+# dummy check, which just cares about basic QCArchive import/usage
+# https://docs.openforcefield.org/projects/toolkit/en/stable/users/molecule_cookbook.html
+record = [*client.query_molecules(molecular_formula="C16H20N3O5")][-1]
+

--- a/recipe/test_openff_toolkit.py
+++ b/recipe/test_openff_toolkit.py
@@ -4,7 +4,7 @@ from openff.toolkit.utils.toolkits import (
     RDKitToolkitWrapper,
 )
 
-from qcportal improt PortalClient
+from qcportal import PortalClient
 
 from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.typing.engines.smirnoff import ForceField

--- a/recipe/test_openff_toolkit.py
+++ b/recipe/test_openff_toolkit.py
@@ -4,7 +4,7 @@ from openff.toolkit.utils.toolkits import (
     RDKitToolkitWrapper,
 )
 
-import qcportal
+from qcportal improt PortalClient
 
 from openff.toolkit.topology import Molecule, Topology
 from openff.toolkit.typing.engines.smirnoff import ForceField


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
