### PR TITLE
No `xmltodict` 1.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   git_depth: -1
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: openff-toolkit-base
@@ -35,7 +35,7 @@ outputs:
         - openff-units
         - openff-utilities
         - networkx >=2.5
-        - xmltodict
+        - xmltodict <1.0.3
         - bson
         - python-constraint
         - cachetools


### PR DESCRIPTION
https://github.com/martinblech/xmltodict/issues/406 / https://github.com/openforcefield/openff-toolkit/issues/2150

This only affects serialization of virtual site parameters

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
